### PR TITLE
Fix negative raim (NGWPC-8227)

### DIFF
--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -857,7 +857,7 @@ contains
           dest(1) = 0.0
           write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim' is negligibly negative (", &
                                  this%model%modelvar%raim_comb, " mm/s), set to 0.0"
-          call write_log(msg, LOG_LEVEL_WARNING)
+          call write_log(msg, LOG_LEVEL_INFO)
           bmi_status = BMI_SUCCESS
 
        ! Throw an error if it’s truly negative


### PR DESCRIPTION
Fixed issue of negative raim (rain + snowmelt) from snow17. 

It is concluded that the occasional extremely small value of negative melt (-2.87394e-08 mm/hr or equivalently 7.98317e-12  mm/s) was very likely due to numerical roundoff errors or floating point artifacts, and not a true negative value.
 
See more details at: https://jira.nextgenwaterprediction.com/browse/NGWPC-8277
This is related to the bug story: https://jira.nextgenwaterprediction.com/browse/NGWPC-7450
