### PR TITLE
Fix logger recursion (NGWPC-8295)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,4 +22,30 @@ cd ../output/             # to view output data
 ```
 Note that the ex1/ example is part of the repo.  The unpacked directory and test contents will not be included in a push back to the online repo.  To the program for other purposes, create new input files and output directories outside of the `snow17/` repository directory, and link to the executable in `snow17/bin/`. 
 
+## Logger
+
+The Errror Warning and Trapping Systems (EWTS) has been added to this module using a logging schema. All write statements have been converted to `write_log` statements, which saves the ouptut to a log file based on the log level.
+
+When running within the ngen framework, the log file and log level are handled programatically. When running standalone, logging is defaulted to DISABLED. 
+
+**Running Standalone**
+
+In order to generate log messages when running standalone, the `NGEN_EWTS_LOGGING` environment variable must be set to `ENABLED`. This is the only required environment variable . Other optional logger environment variables exist for specifying the log file full pathname and setting the log level. If the user only enables logging, the log level will be set to INFO and the filename will be created based on the user and module names. All logger setup details are written to the console when the module is run. 
+```
+# Case Sensitive
+export NGEN_EWTS_LOGGING=ENABLED
+export NGEN_LOG_FILE_PATH=<full pathname for log file>
+export SNOW17_LOGLEVEL=<DEBUG, INFO, WARNING, SEVERE, FATAL>
+```
+**Log Levels**
+| Level   | Description                                         | Typical Use                                   |
+|---------|-----------------------------------------------------|-----------------------------------------------|
+| DEBUG   | Detailed diagnostic info for development/troubleshooting. | Variable values, function entry/exit. |
+| FATAL   | Critical failure that aborts or makes app unrecoverable. | Crashes, memory errors, invalid state.        |
+| INFO    | General events confirming expected operations.       | Startup/shutdown, configs, task completions.  |
+| SEVERE  | Significant problem; app may continue in degraded state. | Failed services, corrupted configs, data loss.|
+| WARNING | Potential issue that doesn’t stop execution.         | Deprecated APIs, missing files, repeatable errors. |
+
+Default log level is INFO. The log level is hierarchical. Setting it to INFO, will log INFO, WARNING, SEVERE and FATAL
+messages.
 


### PR DESCRIPTION
While testing Sac-SMA standalone, a run-time error occurred due to a recursive call to write_log. When write_log starts, it call initialize, which calls set_log_file_path which calls write_log. Refactored to use print statements since these really were not necessary in the log file, thereby removing recursion. 

## Additions

- Comments providing instructions on enabling the EWTS logger when running the module stand-alone.

## Removals

- Unnecessary string building code for the removed write_log statements during initialization.

## Changes

- Converted write_log statements while initializing the logger to print statements.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
