### PR TITLE
Idt serialization 9779

### DIFF
--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -850,7 +850,7 @@ contains
 !        bmi_status = BMI_SUCCESS
     case("serialization_size")
       if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
-         dest = size(this%model%serialization_buffer)
+         dest(:) = sizeof(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
       else
          call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -850,7 +850,7 @@ contains
 !        bmi_status = BMI_SUCCESS
     case("serialization_size")
       if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) == 0) then
-         dest = size(this%model%serialization_buffer)
+         dest = sizeof(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
       else
          call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -581,8 +581,8 @@ contains
     character (len=*), intent(in) :: name
     character (len=*), intent(out) :: type
     integer :: bmi_status
-    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "uint64" !pads spaces upto 2048.
-    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "uint64" !pads spaces upto 2048
+    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
+    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_state = "character" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
@@ -615,6 +615,9 @@ contains
        bmi_status = BMI_SUCCESS
     case ('serialization_free')
        type = ser_free
+       bmi_status = BMI_SUCCESS
+    case ("reset_time")
+       type = "double"
        bmi_status = BMI_SUCCESS
     case default
        type = "-"
@@ -780,6 +783,11 @@ contains
     case("adc11")
        size = sizeof(this%model%parameters%adc(11,:))
        bmi_status = BMI_SUCCESS
+    case("serialization_size", "serialization_create", "serialization_free", "reset_time")
+       bmi_status = snow17_var_nbytes(this, name, size)
+    case("serialization_state")
+       size = 1
+       bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -794,9 +802,13 @@ contains
     integer, intent(out) :: nbytes
     integer :: bmi_status
     integer :: s1, s2, s3, grid, grid_size, item_size
+    double precision :: d
     
     if (name == "serialization_create" .or. name == "serialization_size") then
-      nbytes = storage_size(0_int64)/8 !returns size in bits. So, divide by 8 for bytes.
+      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
+      bmi_status = BMI_SUCCESS
+    else if (name == "reset_time") then
+      nbytes = storage_size(d) / 8
       bmi_status = BMI_SUCCESS
     else if (name == "serialization_state") then
       if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
@@ -854,10 +866,23 @@ contains
 !        bmi_status = BMI_SUCCESS
     case("serialization_size")
         if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
+            if (this%model%serialization_size > 0) then
+               dest = this%model%serialization_size
+               bmi_status = BMI_SUCCESS
+            else
+               call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+               bmi_status = BMI_FAILURE
+            end if
+        else
+            dest = size(this%model%serialization_buffer)
+            bmi_status = BMI_SUCCESS
+         end if
+    case("serialization_state")
+        if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
         else
-            dest = size(this%model%serialization_buffer,KIND=int64)
+            dest = this%model%serialization_buffer
             bmi_status = BMI_SUCCESS
          end if
     case default
@@ -1033,9 +1058,6 @@ contains
  !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR INTEGER VARS =================
 
      select case(name)
-     case("serialization_state")
-          dest_ptr = this%model%serialization_buffer
-          bmi_status = BMI_SUCCESS
      case default
         bmi_status = BMI_FAILURE
         call write_log("snow17_get_ptr_int - " // name // " not found.", LOG_LEVEL_SEVERE)
@@ -1156,6 +1178,7 @@ contains
             bmi_status = BMI_FAILURE
             call write_log(" Failed to create serialized data for state saving", LOG_LEVEL_FATAL) 
          end if
+         this%model%serialization_size = -1
       case("serialization_state")
          call deserialize_mp_buffer(this%model,src, exec_status)
          if (exec_status == 0) then
@@ -1165,20 +1188,16 @@ contains
             bmi_status = BMI_FAILURE
             call write_log(" Failed to deserialize state saving data", LOG_LEVEL_FATAL) 
          end if
+         this%model%serialization_size = -1
       case("serialization_free")
          if(allocated(this%model%serialization_buffer)) then
             deallocate(this%model%serialization_buffer)
          end if
          bmi_status = BMI_SUCCESS
-      case("reset_time")
-         call reset_model_time(this%model, exec_status)
-         if (exec_status == 0) then
-            bmi_status = BMI_SUCCESS
-            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
-         else
-            bmi_status = BMI_FAILURE
-            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
-         end if
+         this%model%serialization_size = -1
+      case("serialization_size")
+         this%model%serialization_size = src(1)
+         bmi_status = BMI_SUCCESS
       case default
        bmi_status = BMI_FAILURE
        call write_log("snow17_set_int - " // name // " not found.", LOG_LEVEL_SEVERE)
@@ -1309,10 +1328,20 @@ contains
     character (len=*), intent(in) :: name
     double precision, intent(in) :: src(:)
     integer :: bmi_status
+    integer(kind=int64) :: exec_status
 
     !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR DOUBLE VARS =================
 
     select case(name)
+    case("reset_time")
+      call reset_model_time(this%model, exec_status)
+      if (exec_status == 0) then
+         bmi_status = BMI_SUCCESS
+         call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
+      else
+         bmi_status = BMI_FAILURE
+         call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+      end if
     case default
        bmi_status = BMI_FAILURE
        call write_log("snow17_set_double - " // name // " not found.", LOG_LEVEL_SEVERE)

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -849,8 +849,8 @@ contains
 !        dest = [this%model%id]
 !        bmi_status = BMI_SUCCESS
     case("serialization_size")
-      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) == 0) then
-         dest = sizeof(this%model%serialization_buffer)
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+         dest = size(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
       else
          call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -796,7 +796,7 @@ contains
       bmi_status = snow17_var_itemsize(this, name, nbytes)
     else if (name == "serialization_state") then
       if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
-         nbytes = size(this%model%serialization_buffer)
+         nbytes = sizeof(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
       else if (this%model%serialization_size > 0) then
          nbytes = this%model%serialization_size

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -1170,6 +1170,15 @@ contains
             deallocate(this%model%serialization_buffer)
          end if
          bmi_status = BMI_SUCCESS
+      case("reset_time")
+         call reset_model_time(this%model, exec_status)
+         if (exec_status == 0) then
+            bmi_status = BMI_SUCCESS
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
+         else
+            bmi_status = BMI_FAILURE
+            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+         end if
       case default
        bmi_status = BMI_FAILURE
        call write_log("snow17_set_int - " // name // " not found.", LOG_LEVEL_SEVERE)

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -583,7 +583,7 @@ contains
     integer :: bmi_status
     character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
     character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
-    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "character" !pads spaces upto 2048
+    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "int" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
     select case(name)

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -581,10 +581,6 @@ contains
     character (len=*), intent(in) :: name
     character (len=*), intent(out) :: type
     integer :: bmi_status
-    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
-    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
-    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "int" !pads spaces upto 2048
-    character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
     select case(name)
     case('tair', 'precip', &                            ! input/output vars
@@ -604,17 +600,8 @@ contains
     case('hru_id')
        type = "character"
        bmi_status = BMI_SUCCESS
-    case ('serialization_create')
-       type = ser_create
-       bmi_status = BMI_SUCCESS
-    case ('serialization_size')
-       type = ser_size
-       bmi_status = BMI_SUCCESS
-    case ('serialization_state')
-       type = ser_state
-       bmi_status = BMI_SUCCESS
-    case ('serialization_free')
-       type = ser_free
+    case ('serialization_create', "serialization_size", "serialization_state", "serialization_free")
+       type = "int"
        bmi_status = BMI_SUCCESS
     case ("reset_time")
        type = "double"
@@ -677,6 +664,7 @@ contains
     character (len=*), intent(in) :: name
     integer, intent(out) :: size
     integer :: bmi_status
+    double precision :: d
     
     ! note: the combined variables are used assuming ngen is interacting with the
     !       catchment-averaged result if snowbands are used
@@ -783,10 +771,11 @@ contains
     case("adc11")
        size = sizeof(this%model%parameters%adc(11,:))
        bmi_status = BMI_SUCCESS
-    case("serialization_size", "serialization_create", "serialization_free", "reset_time")
-       bmi_status = snow17_var_nbytes(this, name, size)
-    case("serialization_state")
-       size = 1
+    case("serialization_size", "serialization_create", "serialization_free", "serialization_state")
+       size = sizeof(0_int32)
+       bmi_status = BMI_SUCCESS
+    case("reset_time")
+       size = sizeof(d)
        bmi_status = BMI_SUCCESS
     case default
        size = -1
@@ -802,26 +791,21 @@ contains
     integer, intent(out) :: nbytes
     integer :: bmi_status
     integer :: s1, s2, s3, grid, grid_size, item_size
-    double precision :: d
     
-    if (name == "serialization_create" .or. name == "serialization_size") then
-      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
-      bmi_status = BMI_SUCCESS
-    else if (name == "reset_time") then
-      nbytes = storage_size(d) / 8
-      bmi_status = BMI_SUCCESS
+    if (name == "serialization_create" .or. name == "serialization_size" .or. name == "serialization_free" .or. name == "reset_time") then
+      bmi_status = snow17_var_itemsize(this, name, nbytes)
     else if (name == "serialization_state") then
-      if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+         nbytes = size(this%model%serialization_buffer)
+         bmi_status = BMI_SUCCESS
+      else if (this%model%serialization_size > 0) then
+         nbytes = this%model%serialization_size
+         bmi_status = BMI_SUCCESS
+      else
          nbytes = -1
          call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
          bmi_status = BMI_FAILURE
-      else
-         nbytes = size(this%model%serialization_buffer,KIND=int64)
-         bmi_status = BMI_SUCCESS
       end if
-    else if (name == "serialization_free") then 
-      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
-      bmi_status = BMI_SUCCESS
     else
       s1 = this%get_var_grid(name, grid)
       s2 = this%get_grid_size(grid, grid_size)
@@ -865,26 +849,21 @@ contains
 !        dest = [this%model%id]
 !        bmi_status = BMI_SUCCESS
     case("serialization_size")
-        if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-            if (this%model%serialization_size > 0) then
-               dest = this%model%serialization_size
-               bmi_status = BMI_SUCCESS
-            else
-               call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-               bmi_status = BMI_FAILURE
-            end if
-        else
-            dest = size(this%model%serialization_buffer)
-            bmi_status = BMI_SUCCESS
-         end if
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) == 0) then
+         dest = size(this%model%serialization_buffer)
+         bmi_status = BMI_SUCCESS
+      else
+         call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+         bmi_status = BMI_FAILURE
+      end if
     case("serialization_state")
-        if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-            bmi_status = BMI_FAILURE
-        else
-            dest = this%model%serialization_buffer
-            bmi_status = BMI_SUCCESS
-         end if
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+         dest(:) = this%model%serialization_buffer(:)
+         bmi_status = BMI_SUCCESS
+      else
+         call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+         bmi_status = BMI_FAILURE
+      end if
     case default
        dest(:) = -1
        bmi_status = BMI_FAILURE

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -416,29 +416,36 @@ contains
 
   FUNCTION transfer_values_to_mp (src) RESULT (dest)
 
-    real, allocatable, dimension(:), intent(in) :: src
-    class(mp_arr_type), allocatable :: dest
-    integer(kind=int64) :: index
+    real, dimension(:), intent(in) :: src
+    type(mp_arr_type) :: dest
+    integer :: lb, ub, index, arr_size
 
-        do index=LBOUND(src,1), UBOUND(src,1)
-            dest%values(index)%obj = mp_float_type(src(index))
-        end do
+    lb = LBOUND(src,1)
+    ub = UBOUND(src,1)
+    arr_size = size(src)
+    dest = mp_arr_type(arr_size)
+    
+    do index = lb, ub
+        dest%values(index)%obj = mp_float_type(src(index))
+    end do
 
   END FUNCTION transfer_values_to_mp
 
-  FUNCTION transfer_values_from_mp (src) RESULT (dest)
+  FUNCTION transfer_values_to_mp_int (src) RESULT (dest)
 
-    class(mp_arr_type), allocatable, intent(in) :: src
-    real, allocatable, dimension(:) :: dest
-    real(kind=real64) :: deserialized_val
-    integer(kind=int64) :: index
-    logical :: status
-        
-        do index=1, src%numelements()
-            call get_real(src%values(index)%obj, deserialized_val, status)
-            dest(index) = deserialized_val
-        end do
+    integer, dimension(:), intent(in) :: src
+    type(mp_arr_type) :: dest
+    integer :: lb, ub, index, arr_size
 
-  END FUNCTION transfer_values_from_mp
+    lb = LBOUND(src,1)
+    ub = UBOUND(src,1)
+    arr_size = size(src)
+    dest = mp_arr_type(arr_size)
+
+    do index = lb, ub
+        dest%values(index)%obj = mp_int_type(src(index))
+    end do
+
+  END FUNCTION transfer_values_to_mp_int
 
 end module runModule

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -313,7 +313,7 @@ contains
         ser_ints = CEILING(real(ser_size) / sizeof(ser_size))
         allocate(model%serialization_buffer(ser_ints + 1))
         model%serialization_buffer(1) = ser_size
-        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)
+        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:))
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -437,11 +437,14 @@ contains
     real(kind=real64) :: deserialized_val
     integer(kind=int64) :: index
     logical :: status
-        
-        do index=1, src%numelements()
-            call get_real(src%values(index)%obj, deserialized_val, status)
-            dest(index) = deserialized_val
-        end do
+    integer :: lb, ub
+
+    lb = LBOUND(src,1)
+    ub = UBOUND(src,1)
+    do index = lb, ub
+      call get_real(src%values(index)%obj, deserialized_val, status)
+      dest(index) = deserialized_val
+    end do
 
   END FUNCTION transfer_values_from_mp
 

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -256,6 +256,17 @@ contains
 
   end subroutine cleanup
 
+  SUBROUTINE reset_model_time(model, exec_status)
+    type(snow17_type), intent(inout) :: model
+    integer(kind=int64), intent(out) :: exec_status
+    exec_status = 1
+    ! reset time variables to the beginning
+    model%runinfo%curr_datetime  = model%runinfo%start_datetime ! start the model with nowdate = startdate
+    model%runinfo%itime          = 1                    ! initialize the time loop counter at 1
+    model%runinfo%time_dbl       = 0.d0                 ! start model run at t = 0.0  
+    exec_status = 0
+  END SUBROUTINE reset_model_time
+  
   SUBROUTINE new_serialization_request (model, exec_status)
     type(snow17_type), intent(inout) :: model
     integer(kind=int64) :: nh !counter for HRUs

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -21,7 +21,7 @@ module runModule
     type(forcing_type)    :: forcing
     type(modelvar_type)   :: modelvar
     integer               :: serialization_size
-    byte, dimension(:), allocatable :: serialization_buffer
+    integer, dimension(:), allocatable :: serialization_buffer
   end type snow17_type
 
 contains
@@ -278,8 +278,7 @@ contains
     class(mp_arr_type), allocatable :: mp_cs_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
-    integer :: ser_size
-    byte, dimension(4) :: byte_size
+    integer :: ser_size, ser_ints
 
     mp = msgpack()
     mp_cs_arr = mp_arr_type(model%runinfo%n_hrus)
@@ -307,14 +306,14 @@ contains
     else
         exec_status = 0
         ! add serialization size at beginning of data as header
-        ser_size = size(serialization_buffer)
         if (allocated(model%serialization_buffer)) then
           deallocate(model%serialization_buffer)
         end if
-        allocate(model%serialization_buffer(ser_size + 4))
-        byte_size = transfer(ser_size, byte_size, size=4)
-        model%serialization_buffer(1:4) = byte_size(1:4)
-        model%serialization_buffer(5:) = serialization_buffer
+        ser_size = size(serialization_buffer)
+        ser_ints = CEILING(real(ser_size) / sizeof(ser_size))
+        allocate(model%serialization_buffer(ser_ints + 1))
+        model%serialization_buffer(1) = ser_size
+        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -438,9 +438,11 @@ contains
     integer(kind=int64) :: index
     logical :: status
     integer :: lb, ub
+    
+    lb = LBOUND(src%values, 1)
+    ub = UBOUND(src%values, 1)
+    allocate(dest(lb:ub))
 
-    lb = LBOUND(src,1)
-    ub = UBOUND(src,1)
     do index = lb, ub
       call get_real(src%values(index)%obj, deserialized_val, status)
       dest(index) = deserialized_val

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -431,21 +431,19 @@ contains
 
   END FUNCTION transfer_values_to_mp
 
-  FUNCTION transfer_values_to_mp_int (src) RESULT (dest)
+  FUNCTION transfer_values_from_mp (src) RESULT (dest)
 
-    integer, dimension(:), intent(in) :: src
-    type(mp_arr_type) :: dest
-    integer :: lb, ub, index, arr_size
+    class(mp_arr_type), allocatable, intent(in) :: src
+    real, allocatable, dimension(:) :: dest
+    real(kind=real64) :: deserialized_val
+    integer(kind=int64) :: index
+    logical :: status
+        
+        do index=1, src%numelements()
+            call get_real(src%values(index)%obj, deserialized_val, status)
+            dest(index) = deserialized_val
+        end do
 
-    lb = LBOUND(src,1)
-    ub = UBOUND(src,1)
-    arr_size = size(src)
-    dest = mp_arr_type(arr_size)
-
-    do index = lb, ub
-        dest%values(index)%obj = mp_int_type(src(index))
-    end do
-
-  END FUNCTION transfer_values_to_mp_int
+  END FUNCTION transfer_values_from_mp
 
 end module runModule

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -20,6 +20,7 @@ module runModule
     type(parameters_type) :: parameters
     type(forcing_type)    :: forcing
     type(modelvar_type)   :: modelvar
+    integer               :: serialization_size
     byte, dimension(:), allocatable :: serialization_buffer
   end type snow17_type
 
@@ -277,6 +278,8 @@ contains
     class(mp_arr_type), allocatable :: mp_cs_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
+    integer :: ser_size
+    byte, dimension(4) :: byte_size
 
     mp = msgpack()
     mp_cs_arr = mp_arr_type(model%runinfo%n_hrus)
@@ -303,7 +306,15 @@ contains
         exec_status = 1
     else
         exec_status = 0
-        model%serialization_buffer = serialization_buffer
+        ! add serialization size at beginning of data as header
+        ser_size = size(serialization_buffer)
+        if (allocated(model%serialization_buffer)) then
+          deallocate(model%serialization_buffer)
+        end if
+        allocate(model%serialization_buffer(ser_size + 4))
+        byte_size = transfer(ser_size, byte_size, size=4)
+        model%serialization_buffer(1:4) = byte_size(1:4)
+        model%serialization_buffer(5:) = serialization_buffer
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request
@@ -325,8 +336,9 @@ contains
     exec_status = 0
     mp = msgpack()
     !convert integer(4) to integer(1) for messagepack
-    allocate(serialized_data_1b(size(serialized_data, 1, int64)*4_int64))
-    serialized_data_1b = transfer(serialized_data, serialized_data_1b) 
+    ! read the size of the data from the first 4 bytes
+    allocate(serialized_data_1b(serialized_data(1)))
+    serialized_data_1b = transfer(serialized_data(2:), serialized_data_1b, size=serialized_data(1)) 
     call mp%unpack(serialized_data_1b, mpv)
     if (.NOT. is_arr(mpv)) then
       call write_log("Deserialized data structure is not a messagepack array. Error: " // mp%error_message, LOG_LEVEL_FATAL)  


### PR DESCRIPTION
This PR adds support for serialization messaging. Some of these changes are based around the limitations of the Fortran BMI interface that limits the use of raw pointers and restricts value types to `int`, `float`, and `double`.

Accepting this PR will include all changes currently in https://github.com/NGWPC/snow17/pull/12

## Additions

- `serialization_size` is a valid input for allowing the `get_value_nbytes` to reflect an incoming size for serialized data. This works around the limitation of passing arbitrarily sized serialization data to the Fortran BMI to read.

## Removals

-

## Changes

- `serialization_size`, `serialization_create`, and `serialization_state` all use `int` as their type for BMI messaging.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
