### PR TITLE
Snow-17 : Fix unit conversion errors in BMI calculation

### DIFF
--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -922,29 +922,30 @@ contains
        else
           bmi_status = BMI_SUCCESS
        end if
+
     case("raim_depth")
         ! Snow-17 stores raim_comb as a rate in mm/s.
         ! NWM ACSNOW expects timestep-integrated depth in mm.
         dest(1) = this%model%modelvar%raim_comb * real(this%model%runinfo%dt)
 
-        ! Handle very small negative values caused by round-off.
-        if (dest(1) < 0.0 .and. dest(1) > -1.0e-6) then
+        ! Match original raim behavior: judge small negative noise using the rate value.
+        if (this%model%modelvar%raim_comb < 0.0 .and. this%model%modelvar%raim_comb > -1.0e-6) then
             dest(1) = 0.0
-            write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim_depth' is negligibly negative (", &
+            write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim_depth' is negligibly negative from raim rate (", &
                                     this%model%modelvar%raim_comb, " mm/s), set to 0.0 mm"
             call write_log(msg, LOG_LEVEL_INFO)
             bmi_status = BMI_SUCCESS
 
-        ! Throw an error if truly negative after conversion.
-        else if (dest(1) <= -1.0e-6) then
-            write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim_depth' is invalid (", &
-                                    dest(1), " mm), must be non-negative."
+        else if (this%model%modelvar%raim_comb <= -1.0e-6) then
+            write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim_depth' is invalid from raim rate (", &
+                                    this%model%modelvar%raim_comb, " mm/s), must be non-negative."
             call write_log(msg, LOG_LEVEL_SEVERE)
             bmi_status = BMI_FAILURE
 
         else
             bmi_status = BMI_SUCCESS
         end if
+
     !case("hru_id")
     !   dest = [this%model%parameters%hru_id]
     !   bmi_status = BMI_SUCCESS

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -637,7 +637,7 @@ contains
        units = "mm"
        bmi_status = BMI_SUCCESS
     case("raim")
-       units = "mm/s"
+       units = "mm"
        bmi_status = BMI_SUCCESS
     case("elev")
        units = "mm/s"
@@ -896,26 +896,26 @@ contains
        dest(1) = this%model%modelvar%snowh_comb
        bmi_status = BMI_SUCCESS
     case("raim")
-       dest(1) = this%model%modelvar%raim_comb
+       ! Snow-17 stores raim_comb as a rate in mm/s.
+       ! NWM ACSNOW/raim output expects timestep depth in mm.
+       dest(1) = this%model%modelvar%raim_comb * real(this%model%runinfo%dt)
 
        ! handle very small negative raim values that can occur due to round-off error or floating-point artifacts
        if (dest(1) < 0.0 .and. dest(1) > -1.0e-6) then
           dest(1) = 0.0
           write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim' is negligibly negative (", &
-                                 this%model%modelvar%raim_comb, " mm/s), set to 0.0"
+                             this%model%modelvar%raim_comb, " mm/s), set to 0.0 mm"
           call write_log(msg, LOG_LEVEL_INFO)
           bmi_status = BMI_SUCCESS
 
-       ! Throw an error if it’s truly negative
-       else if (this%model%modelvar%raim(1) <= -1.0e-6) then
-          write(msg,'(A,ES12.5,A)') "snow17_get_float - 'raim' is invalid (", this%model%modelvar%raim(1), \
-                                 " mm/s), must be non-negative."
+       else if (dest(1) <= -1.0e-6) then
+          write(msg,'(A,ES12.5,A)') "snow17_get_float - 'raim' is invalid (", &
+                             dest(1), " mm), must be non-negative."
           call write_log(msg, LOG_LEVEL_SEVERE)
           bmi_status = BMI_FAILURE
        else
           bmi_status = BMI_SUCCESS
        end if
-
     !case("hru_id")
     !   dest = [this%model%parameters%hru_id]
     !   bmi_status = BMI_SUCCESS

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -904,18 +904,44 @@ contains
        bmi_status = BMI_SUCCESS
     case("raim")
        dest(1) = this%model%modelvar%raim_comb
-       bmi_status = BMI_SUCCESS  
+
+       ! handle very small negative raim values that can occur due to round-off error or floating-point artifacts
+       if (dest(1) < 0.0 .and. dest(1) > -1.0e-6) then
+          dest(1) = 0.0
+          write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim' is negligibly negative (", &
+                                 this%model%modelvar%raim_comb, " mm/s), set to 0.0"
+          call write_log(msg, LOG_LEVEL_INFO)
+          bmi_status = BMI_SUCCESS
+
+       ! Throw an error if it’s truly negative
+       else if (this%model%modelvar%raim(1) <= -1.0e-6) then
+          write(msg,'(A,ES12.5,A)') "snow17_get_float - 'raim' is invalid (", this%model%modelvar%raim(1), \
+                                 " mm/s), must be non-negative."
+          call write_log(msg, LOG_LEVEL_SEVERE)
+          bmi_status = BMI_FAILURE
+       else
+          bmi_status = BMI_SUCCESS
+       end if
     case("raim_depth")
         ! Snow-17 stores raim_comb as a rate in mm/s.
-        ! NWM ACSNOW expects timestep depth in mm.
+        ! NWM ACSNOW expects timestep-integrated depth in mm.
         dest(1) = this%model%modelvar%raim_comb * real(this%model%runinfo%dt)
 
+        ! Handle very small negative values caused by round-off.
         if (dest(1) < 0.0 .and. dest(1) > -1.0e-6) then
             dest(1) = 0.0
+            write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim_depth' is negligibly negative (", &
+                                    this%model%modelvar%raim_comb, " mm/s), set to 0.0 mm"
+            call write_log(msg, LOG_LEVEL_INFO)
             bmi_status = BMI_SUCCESS
+
+        ! Throw an error if truly negative after conversion.
         else if (dest(1) <= -1.0e-6) then
-            call write_log("snow17_get_float - 'raim_depth' is invalid; must be non-negative.", LOG_LEVEL_SEVERE)
+            write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim_depth' is invalid (", &
+                                    dest(1), " mm), must be non-negative."
+            call write_log(msg, LOG_LEVEL_SEVERE)
             bmi_status = BMI_FAILURE
+
         else
             bmi_status = BMI_SUCCESS
         end if

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -98,7 +98,7 @@ module bmi_snow17_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 2
-  integer, parameter :: output_item_count = 4
+  integer, parameter :: output_item_count = 5
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -159,6 +159,7 @@ contains
     output_items(2) = 'sneqv'        ! snow water equivalent (mm)
     output_items(3) = 'snowh'        ! snow height (mm)
     output_items(4) = 'raim'         ! precipitation (liquid) plus snowmelt (mm/s)
+    output_items(5) = 'raim_depth'   ! timestep-integrated raim depth (mm)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -286,7 +287,7 @@ contains
 
     select case(name)
     case('tair', 'precip', &                       ! input/output vars (can pass forc to output)
-         'precip_scf', 'sneqv', 'snowh', 'raim')   ! output vars
+         'precip_scf', 'sneqv', 'snowh', 'raim', 'raim_depth')   ! output vars
        grid = 0
        bmi_status = BMI_SUCCESS
     case('scf', 'mfmax', 'mfmin', 'uadj', 'si', &       ! parameters
@@ -584,7 +585,7 @@ contains
 
     select case(name)
     case('tair', 'precip', &                            ! input/output vars
-         'precip_scf', 'sneqv', 'snowh', 'raim')        ! output vars
+         'precip_scf', 'sneqv', 'snowh', 'raim', 'raim_depth')        ! output vars
        type = "real"
        bmi_status = BMI_SUCCESS
     case('scf', 'mfmax', 'mfmin', 'uadj', 'si', &       ! parameters
@@ -637,6 +638,9 @@ contains
        units = "mm"
        bmi_status = BMI_SUCCESS
     case("raim")
+       units = "mm/s"
+       bmi_status = BMI_SUCCESS
+    case("raim_depth")
        units = "mm"
        bmi_status = BMI_SUCCESS
     case("elev")
@@ -688,6 +692,9 @@ contains
        size = sizeof(this%model%modelvar%snowh_comb)
        bmi_status = BMI_SUCCESS
     case("raim")
+       size = sizeof(this%model%modelvar%raim_comb)
+       bmi_status = BMI_SUCCESS
+    case("raim_depth")
        size = sizeof(this%model%modelvar%raim_comb)
        bmi_status = BMI_SUCCESS
     case("hru_id")
@@ -896,26 +903,22 @@ contains
        dest(1) = this%model%modelvar%snowh_comb
        bmi_status = BMI_SUCCESS
     case("raim")
-       ! Snow-17 stores raim_comb as a rate in mm/s.
-       ! NWM ACSNOW/raim output expects timestep depth in mm.
-       dest(1) = this%model%modelvar%raim_comb * real(this%model%runinfo%dt)
+       dest(1) = this%model%modelvar%raim_comb
+       bmi_status = BMI_SUCCESS  
+    case("raim_depth")
+        ! Snow-17 stores raim_comb as a rate in mm/s.
+        ! NWM ACSNOW expects timestep depth in mm.
+        dest(1) = this%model%modelvar%raim_comb * real(this%model%runinfo%dt)
 
-       ! handle very small negative raim values that can occur due to round-off error or floating-point artifacts
-       if (dest(1) < 0.0 .and. dest(1) > -1.0e-6) then
-          dest(1) = 0.0
-          write(msg, '(A,ES12.5,A)') "snow17_get_float - 'raim' is negligibly negative (", &
-                             this%model%modelvar%raim_comb, " mm/s), set to 0.0 mm"
-          call write_log(msg, LOG_LEVEL_INFO)
-          bmi_status = BMI_SUCCESS
-
-       else if (dest(1) <= -1.0e-6) then
-          write(msg,'(A,ES12.5,A)') "snow17_get_float - 'raim' is invalid (", &
-                             dest(1), " mm), must be non-negative."
-          call write_log(msg, LOG_LEVEL_SEVERE)
-          bmi_status = BMI_FAILURE
-       else
-          bmi_status = BMI_SUCCESS
-       end if
+        if (dest(1) < 0.0 .and. dest(1) > -1.0e-6) then
+            dest(1) = 0.0
+            bmi_status = BMI_SUCCESS
+        else if (dest(1) <= -1.0e-6) then
+            call write_log("snow17_get_float - 'raim_depth' is invalid; must be non-negative.", LOG_LEVEL_SEVERE)
+            bmi_status = BMI_FAILURE
+        else
+            bmi_status = BMI_SUCCESS
+        end if
     !case("hru_id")
     !   dest = [this%model%parameters%hru_id]
     !   bmi_status = BMI_SUCCESS

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -98,7 +98,7 @@ module bmi_snow17_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 2
-  integer, parameter :: output_item_count = 5
+  integer, parameter :: output_item_count = 6
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -160,6 +160,7 @@ contains
     output_items(3) = 'snowh'        ! snow height (mm)
     output_items(4) = 'raim'         ! precipitation (liquid) plus snowmelt (mm/s)
     output_items(5) = 'raim_depth'   ! timestep-integrated raim depth (mm)
+    output_items(6) = 'sneqv_kg_m2'  ! NWM-facing SNEQV mass per area (kg m-2)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -287,7 +288,7 @@ contains
 
     select case(name)
     case('tair', 'precip', &                       ! input/output vars (can pass forc to output)
-         'precip_scf', 'sneqv', 'snowh', 'raim', 'raim_depth')   ! output vars
+         'precip_scf', 'sneqv', 'snowh', 'raim', 'raim_depth', 'sneqv_kg_m2')   ! output vars
        grid = 0
        bmi_status = BMI_SUCCESS
     case('scf', 'mfmax', 'mfmin', 'uadj', 'si', &       ! parameters
@@ -585,7 +586,7 @@ contains
 
     select case(name)
     case('tair', 'precip', &                            ! input/output vars
-         'precip_scf', 'sneqv', 'snowh', 'raim', 'raim_depth')        ! output vars
+         'precip_scf', 'sneqv', 'snowh', 'raim', 'raim_depth', 'sneqv_kg_m2')        ! output vars
        type = "real"
        bmi_status = BMI_SUCCESS
     case('scf', 'mfmax', 'mfmin', 'uadj', 'si', &       ! parameters
@@ -632,8 +633,11 @@ contains
        units = "mm/s"
        bmi_status = BMI_SUCCESS
     case("sneqv")
-       units = "kg m-2"
+       units = "mm"
        bmi_status = BMI_SUCCESS
+    case("sneqv_kg_m2")
+       units = "kg m-2"
+       bmi_status = BMI_SUCCESS   
     case("snowh")
        units = "mm"
        bmi_status = BMI_SUCCESS
@@ -686,6 +690,9 @@ contains
        size = sizeof(this%model%forcing%precip_scf_comb)
        bmi_status = BMI_SUCCESS
     case("sneqv")
+       size = sizeof(this%model%modelvar%sneqv_comb)
+       bmi_status = BMI_SUCCESS
+    case("sneqv_kg_m2")
        size = sizeof(this%model%modelvar%sneqv_comb)
        bmi_status = BMI_SUCCESS
     case("snowh")
@@ -897,6 +904,11 @@ contains
        dest(1) = this%model%forcing%precip_scf_comb
        bmi_status = BMI_SUCCESS
     case("sneqv")
+       dest(1) = this%model%modelvar%sneqv_comb
+       bmi_status = BMI_SUCCESS
+    case("sneqv_kg_m2")
+       ! Snow-17 stores sneqv_comb as mm water-equivalent depth.
+       ! NWM expects kg m-2. Numerically, 1 mm water = 1 kg m-2.
        dest(1) = this%model%modelvar%sneqv_comb
        bmi_status = BMI_SUCCESS
     case("snowh")

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -631,7 +631,7 @@ contains
        units = "mm/s"
        bmi_status = BMI_SUCCESS
     case("sneqv")
-       units = "mm"
+       units = "kg m-2"
        bmi_status = BMI_SUCCESS
     case("snowh")
        units = "mm"


### PR DESCRIPTION

https://jira.nextgenwaterprediction.com/browse/NGWPC-10216

**Issue**
raim was exposed in mm/s (rate) while NWM expects mm (timestep depth)
sneqv was exposed in mm (depth) while NWM expects kg m⁻² (mass per area)

This caused NGEN warnings:
Unable to convert mm/s to mm
Unable to convert mm to kg/m2

**Fix**

Instead of modifying existing variables, two new BMI output variables were introduced:

raim_depth   → mm
sneqv_kg_m2  → kg m⁻²

Computed as:

raim_depth  = raim × timestep_seconds
sneqv_kg_m2 = sneqv_mm   (1 mm water = 1 kg m⁻²)

The original variables remain unchanged:

raim  → mm/s
sneqv → mm

**Why**
Preserves Snow-17 native semantics
Avoids redefining existing variables
Aligns with NWM requirements (ACSNOW, SNEQV)
Maintains consistency with updates across other modules

**Result**
Eliminates unit conversion warnings
Provides physically correct NWM-compatible outputs
Maintains backward compatibility and clarity